### PR TITLE
updated the codebase to use a number for each table

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mensa-pwa-react",
-  "version": "1.2.2",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mensa-pwa-react",
-      "version": "1.2.2",
+      "version": "1.15.0",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
         "@emotion/react": "^11.11.1",

--- a/client/src/components/CodeGuide.js
+++ b/client/src/components/CodeGuide.js
@@ -20,7 +20,8 @@ const steps = [
       'Jeder Sitzplatz-Code besteht aus drei Stellen.',
       'Erste Stelle: Bereich der Mensa (N, M, S).',
       'Zweite Stelle: Position oder Etage (Zahl).',
-      'Dritte Stelle: Nähe zur Mitte oder Richtung (Buchstabe).'
+      'Dritte Stelle: Nähe zur Mitte oder Richtung (Buchstabe).',
+      'Vierte Stelle: Nummer des tisches mit "-" vorangestellt(Zahl). (Wichtig für Tische mit gleichen Codes)'
     ],
     image: ImageCodes
   },
@@ -54,10 +55,9 @@ const steps = [
   {
     heading: 'Beispiele',
     content: [
-      '"N12I": Nördlicher Bereich, 12 Uhr, innen.',
-      '"M2S": Mittlerer Bereich, 2. Etage, südlich.',
-      '"S7A": Südlicher Bereich, 7 Uhr, außen.',
-      'Beachte, dass unter einem Code auch mehrere Tische fallen können.'
+      '"N12I-1": Nördlicher Bereich, 12 Uhr, innen.',
+      '"M2S-2": Mittlerer Bereich, 2. Etage, südlich.',
+      '"S7A-3": Südlicher Bereich, 7 Uhr, außen.'
     ],
     image: ImageExamples
   }

--- a/client/src/components/FloorplanSelector.js
+++ b/client/src/components/FloorplanSelector.js
@@ -24,6 +24,19 @@ function FloorplanSelector() {
   // Array to hold table elements
   let tables = [];
 
+
+  // For Legacy format (e.g. S1A, N2I, etc.)
+  if(checkForOldFormat(code)) {
+    console.log('Old format detected');
+    code = code + '-1';
+    console.log('New code: ' + code);
+  }
+
+  function checkForOldFormat (input) {
+    let regex = /^[A-Za-z][0-9]+[A-Za-z]$/i;
+    return regex.test(input);
+  }  
+
   // Function to handle zooming
   function zoomed(event, image) {
     const { transform } = event;
@@ -129,7 +142,7 @@ function FloorplanSelector() {
   function getLocationCode(id) {
     const segments = id.split("_");
     if (segments.length >= 2) {
-      let locationCode = segments[1];
+      let locationCode = segments[1] + "-" + segments[2];
       locationCode = locationCode.replace(/R/g, "S");
       locationCode = locationCode.replace(/L/g, "N");
       return locationCode;

--- a/client/src/utils/codeValidation.js
+++ b/client/src/utils/codeValidation.js
@@ -1,42 +1,63 @@
+import floorPlanImage from '../assets/mensaplan.svg'
+
 /**
- * This function generates all valid codes.
- * A valid code is a combination of a first letter, a number, and a last letter.
- * The first letter can be 'N', 'S', or 'M'.
- * The number can be from 1 to 12 for 'N' and 'S', and 0 to 3 for 'M'.
- * The last letter can be 'A' or 'I' for 'N' and 'S', and 'N' or 'S' for 'M'.
- * Example: 'N1A', 'S12I', 'M0N', 'M3S' are valid codes.
+ * Fetches an SVG floor plan image, parses it, and extracts all table elements.
+ *
+ * @async
+ * @function getAllTablesFromSVG
+ * @returns {Promise<string[]>} A promise that resolves to an array of table IDs.
+ * @throws {Error} If there is an issue with fetching or parsing the SVG.
  */
-export const generateValidCodes = () => {
-  const firstLetters = ['N', 'S', 'M'];
-  const numbers = {
-    'N': Array.from({ length: 12 }, (_, i) => i + 1),
-    'S': Array.from({ length: 12 }, (_, i) => i + 1),
-    'M': [0, 1, 2, 3],
-  };
-  const lastLetters = {
-    'N': ['A', 'I'],
-    'S': ['A', 'I'],
-    'M': ['N', 'M', 'S'],
-  };
-
-  let combinations = [];
-  firstLetters.forEach(firstLetter => {
-    numbers[firstLetter].forEach(number => {
-      lastLetters[firstLetter].forEach(lastLetter => {
-        combinations.push(firstLetter + number + lastLetter);
-      });
-    });
-  });
-
-  return combinations;
+export const getAllTablesFromSVG = async () => {
+  const response = await fetch(floorPlanImage);
+  const svgText = await response.text();
+  const parser = new DOMParser();
+  const svg = parser.parseFromString(svgText, 'image/svg+xml');
+  const tables = svg.querySelectorAll("g > *[id*='Table']");
+  return Array.from(tables).map(table => table.id);
 }
 
 /**
- * This function checks if a code is valid.
- * It ignores the case of the code.
- * Example: 'n1a', 'S12i', 'M0n', 'm3S' are considered valid.
+ * Converts table IDs by splitting each ID on underscores, removing the first part,
+ * joining the remaining parts with hyphens, and replacing 'R' with 'S' and 'L' with 'N'.
+ *
+ * @param {string[]} tables - An array of table ID strings to be converted.
+ * @returns {string[]} An array of converted table ID strings.
+ */
+export const convertTableIds = (tables) => {
+  return tables.map(table => table.split('_').slice(1).join('-').replace(/R/g, 'S').replace(/L/g, 'N'));
+}
+
+/**
+ * Validates the provided code by checking if it exists in the list of tables
+ * obtained from the SVG.
+ *
+ * @param {string} code - The code to be validated.
+ * @returns {Promise<boolean>} - A promise that resolves to true if the code is valid, otherwise false.
  */
 export const isValidCode = (code) => {
-  const combinations = generateValidCodes();
-  return combinations.includes(code.toUpperCase());
-}
+  return getAllTablesFromSVG()
+    .then((tables) => {
+      tables = convertTableIds(tables);
+
+      if (!tables || tables.length === 0) {
+        console.error('No tables found in the SVG.');
+        return false;  // No tables => invalid
+      }
+
+      if (tables.includes(code.toUpperCase())) {
+        return true;
+      } else {
+        console.log('Check for old format');
+        const oldFormat = tables.map(table => table.split('-').slice(0, -1).join('-'));
+        if(oldFormat.includes(code.toUpperCase())) {
+          return true;
+        }
+      }
+      return false;
+    })
+    .catch((err) => {
+      console.error(err);
+      return false;
+    });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "MensaPWA",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
I have updated the FlooplanSelector.js to also include the number of the id from the tables of the svg which allows for a more precise selection of a table.
I also changed the codeValidation.js to reflect these changes (valid tables are fetched now by getting the Table ID's directly from the Table).
This is also compatible with old Links. When an old link is being used, it will just append a '-1' to match the new style.